### PR TITLE
Support uv with tox-uv

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,11 @@ Please vendor the plugin as described below, or you _will_ get broken.
 1. Install `tox-ignore-env-name-mismatch` in the same environment as `tox`.
 2. Set `runner = ignore_env_name_mismatch` in a testenv to opt-out of recreating the virtualenv when the env name changes.
 
+If you prefer to use [uv](https://github.com/astral-sh/uv) alongside [tox-uv](https://github.com/tox-dev/tox-uv) for extra speed:
+
+1. Install `tox-ignore-env-name-mismatch[uv]`
+2. Set `runner = ignore_env_name_mismatch_uv`
+
 ### To always use this plugin:
 
 #### Vendor

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,9 @@ authors = [
     {name = "Masen Furer", email = "m_github@0x26.net"},
 ]
 requires-python = ">=3.7"
+optional-dependencies.uv = [
+  "tox-uv",
+]
 license = {file = "LICENSE"}
 classifiers = [
     'Development Status :: 4 - Beta',

--- a/tests/integration/test_end_to_end.py
+++ b/tests/integration/test_end_to_end.py
@@ -17,6 +17,7 @@ TOUCH_SCRIPT = (
     "ignore_env_name_mismatch_spec, exp_reuse",
     [
         ["runner = ignore_env_name_mismatch", True],
+        ["runner = ignore_env_name_mismatch_uv", True],
         ["", False],
     ],
 )
@@ -53,7 +54,14 @@ def test_testenv_reuse(pytester, monkeypatch, ignore_env_name_mismatch_spec, exp
         assert f"{env}.txt" not in names_in_shared
 
 
-def test_testenv_no_reuse(pytester, monkeypatch):
+@pytest.mark.parametrize(
+    "runner",
+    [
+        "ignore_env_name_mismatch",
+        "ignore_env_name_mismatch_uv",
+    ],
+)
+def test_testenv_no_reuse(pytester, monkeypatch, runner):
     """Although ignore_env_name_mismatch = true, the env can be recreated for other reasons."""
     monkeypatch.delenv("TOX_WORK_DIR", raising=False)
     pytester.makeini(
@@ -64,14 +72,14 @@ def test_testenv_no_reuse(pytester, monkeypatch):
 
             [testenv]
             env_dir = {toxworkdir}{/}shared
-            runner = ignore_env_name_mismatch
+            runner = %s
             deps = wheel
             commands = %s
 
             [testenv:bar]
             deps = wheel < 38.4
             """
-            % TOUCH_SCRIPT
+            % (runner, TOUCH_SCRIPT)
         )
     )
     resp = pytester.run(sys.executable, "-m", "tox")

--- a/tests/integration/test_end_to_end.py
+++ b/tests/integration/test_end_to_end.py
@@ -29,12 +29,14 @@ def test_testenv_reuse(pytester, monkeypatch, ignore_env_name_mismatch_spec, exp
     pytester.makeini(
         dedent(
             """
+            [tox]
+            env_list = %s
             [testenv]
             env_dir = {toxworkdir}{/}shared
             %s
             commands = %s
             """
-            % (ignore_env_name_mismatch_spec, TOUCH_SCRIPT)
+            % (",".join(envlist), ignore_env_name_mismatch_spec, TOUCH_SCRIPT)
         ),
     )
     pytester.run(sys.executable, "-m", "tox", "-e", ",".join(envlist))

--- a/tests/unit/test_ignore_env_name_mismatch.py
+++ b/tests/unit/test_ignore_env_name_mismatch.py
@@ -7,10 +7,27 @@ import pytest
 import tox_ignore_env_name_mismatch
 
 
+@mock.patch("tox_ignore_env_name_mismatch.UV_INSTALLED", False)
 def test_tox_register_tox_env_mock():
     register_mock = mock.Mock()
     tox_ignore_env_name_mismatch.tox_register_tox_env(register_mock)
-    register_mock.add_run_env.assert_called_once()
+    assert register_mock.add_run_env.mock_calls == [
+        mock.call(tox_ignore_env_name_mismatch.IgnoreEnvNameMismatchVirtualEnvRunner),
+    ]
+    assert (
+        register_mock.default_env_runner
+        != tox_ignore_env_name_mismatch.IgnoreEnvNameMismatchVirtualEnvRunner.id()
+    )
+
+
+@mock.patch("tox_ignore_env_name_mismatch.UV_INSTALLED", True)
+def test_tox_register_tox_env_mock_with_uv():
+    register_mock = mock.Mock()
+    tox_ignore_env_name_mismatch.tox_register_tox_env(register_mock)
+    assert register_mock.add_run_env.mock_calls == [
+        mock.call(tox_ignore_env_name_mismatch.IgnoreEnvNameMismatchVirtualEnvRunner),
+        mock.call(tox_ignore_env_name_mismatch.IgnoreEnvNameMismatchUvVenvRunner),
+    ]
     assert (
         register_mock.default_env_runner
         != tox_ignore_env_name_mismatch.IgnoreEnvNameMismatchVirtualEnvRunner.id()

--- a/tox.ini
+++ b/tox.ini
@@ -18,6 +18,7 @@ deps =
   pytest-cov
   pytest-randomly
   tox >= 4
+  tox-uv
 #  pytest-xdist
 commands =
   pytest {posargs:--cov tox_ignore_env_name_mismatch}
@@ -38,6 +39,7 @@ deps =
   mypy > 0.990, < 0.999
   # tox3 is not py.typed
   tox >= 4.0.0
+  tox-uv
 commands =
   black --check setup.py src/ tests/
   flake8 setup.py src/ tests/


### PR DESCRIPTION
I've added support for reusing environments with `uv` as well.

Also fixed the tests since they were broken in a tox update, now we need to list all envs in `env_list`: https://github.com/tox-dev/tox/issues/3096